### PR TITLE
Fixes of the most severe bugs in CabParser

### DIFF
--- a/src/dorkbox/cabParser/CabInputStream.java
+++ b/src/dorkbox/cabParser/CabInputStream.java
@@ -109,8 +109,34 @@ final class CabInputStream extends InputStream {
 
     @Override
     public long skip(long ammount) throws IOException {
-        long l = this.inputStream.skip(ammount);
+        long l = betterSkip(this.inputStream, ammount);
         this.position += (int) l;
         return l;
     }
+    
+    /**
+     * Reliably skips over and discards n bytes of data from the input stream
+     * @param is input stream
+     * @param n the number of bytes to be skipped
+     * @return the actual number of bytes skipped
+     * @throws IOException
+     */
+    public static long betterSkip(InputStream is, long n) throws IOException {
+        long left = n;
+        while(left > 0) {
+            long l = is.skip(left);
+            if(l > 0) {
+                left -= l;
+            } else if(l == 0) { // should we retry? lets read one byte
+                if(is.read() == -1)  // EOF
+                    break;
+                else 
+                    left--;
+            } else {
+                throw new IOException("skip() returned a negative value. This should never happen");
+            }
+        }
+        return n - left;
+    }
+    
 }

--- a/src/dorkbox/cabParser/CabParser.java
+++ b/src/dorkbox/cabParser/CabParser.java
@@ -113,11 +113,6 @@ public final class CabParser {
     private void readData() throws CabException, IOException {
         this.header = new CabHeader(this.streamSaver);
         this.header.read(this.cabInputStream);
-
-        if (this.header.cbCabinet <= 2147483647L) {
-            this.cabInputStream.mark((int) this.header.cbCabinet);
-        }
-
         this.folders = new CabFolderEntry[this.header.cFolders];
         for (int i = 0; i < this.header.cFolders; i++) {
             this.folders[i] = new CabFolderEntry();
@@ -130,10 +125,6 @@ public final class CabParser {
         for (int i = 0; i < this.header.cFiles; i++) {
             this.files[i] = new CabFileEntry();
             this.files[i].read(this.cabInputStream);
-        }
-
-        if (this.header.cbCabinet <= 2147483647L) {
-            this.cabInputStream.mark((int) this.header.cbCabinet);
         }
     }
 


### PR DESCRIPTION
Those are the fixes of three most severe bugs I found in CabParser when extracting files from [wsusscn2.cab](http://go.microsoft.com/fwlink/?LinkID=74689).
To test the LZX decompressor fix, try to extract file package62.cab from wsusscn2.cab, and binary compare it with the same file, but extracted with some standard native cab extractor. In my case, package62.cab differed in only two bytes at addresses: 0x00C8A706 and 0x011E2706, which prevented CabParser later to extract files from package62.cab.
The details about two other fixes are explained in their commit messages.
There are other bugs in CabParser, but those bugs affect only the code that is extracting many files from the same Cab Input Stream using custom CabParser. I can create pull requests for them later, if you are interested in it.