### PR TITLE
Bug fixes in CabParser

### DIFF
--- a/src/dorkbox/cabParser/DefaultCabStreamSaver.java
+++ b/src/dorkbox/cabParser/DefaultCabStreamSaver.java
@@ -51,12 +51,14 @@ public class DefaultCabStreamSaver implements CabStreamSaver{
         if (outputStream != null) {
             try {
                 ByteArrayOutputStream bos = (ByteArrayOutputStream)outputStream;
-                byte[] bytes=bos.toByteArray();
-                String filePath = extractPath.getAbsolutePath()+File.separator+entry.getName();
-                File cabEntityFile = new File(filePath);
-                cabEntityFile.createNewFile();
+                File cabEntityFile = new File(extractPath, entry.getName().replace("\\", File.separator));
+                cabEntityFile.getParentFile().mkdirs();
                 FileOutputStream fileOutputStream = new FileOutputStream(cabEntityFile);
-                fileOutputStream.write(bytes);
+		try {
+		    bos.writeTo(fileOutputStream);
+                } finally {
+                    fileOutputStream.close();
+                }
             } catch (FileNotFoundException e) {
             } catch (IOException e) {
             } finally {

--- a/src/dorkbox/cabParser/decompress/CabDecompressor.java
+++ b/src/dorkbox/cabParser/decompress/CabDecompressor.java
@@ -91,6 +91,8 @@ public final class CabDecompressor implements CabConstants {
     }
 
     public void initialize(int compressionMethod) throws CabException {
+        this.outputOffset = 0;
+        this.uncompressedDataSize = 0L;
         int type = compressionMethod & 0xF;
         int windowBits = (compressionMethod & 0x1F00) >>> 8;
 

--- a/src/dorkbox/cabParser/extractor/CabExtractor.java
+++ b/src/dorkbox/cabParser/extractor/CabExtractor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dorkbox/cabParser/extractor/CabExtractor.java
+++ b/src/dorkbox/cabParser/extractor/CabExtractor.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import dorkbox.cabParser.CabException;
+import dorkbox.cabParser.CabParser;
+import dorkbox.cabParser.CabStreamSaver;
+import dorkbox.cabParser.structure.CabFileEntry;
+import dorkbox.cabParser.structure.CabFolderEntry;
+import dorkbox.cabParser.structure.CabHeader;
+
+/**
+ * Extracts the content of CAB (file or stream).
+ */
+public class CabExtractor {
+
+    private final InputStream inputStream;
+    private final CabParser parser;
+    private final AtomicBoolean done = new AtomicBoolean(false);
+
+    /**
+     * To extract all files from CAB file and save to sub-directory (named after
+     * CAB file name) of working directory.
+     * 
+     * @param cabFile
+     *            CAB file
+     */
+    public CabExtractor(File cabFile) throws CabException, IOException {
+        this(cabFile, null, new DefaultCabFileSaver(null, cabFile));
+    }
+
+    /**
+     * To extract some files from CAB file and save to sub-directory (named
+     * after CAB file name) of working directory.
+     * 
+     * @param cabFile
+     *            CAB file
+     * @param filter
+     *            which files to extract (extract all files if
+     *            <code>null</code>)
+     */
+    public CabExtractor(File cabFile, CabFileFilter filter) throws CabException, IOException {
+        this(cabFile, filter, new DefaultCabFileSaver(null, cabFile));
+    }
+
+    /**
+     * To extract some files from CAB file and save to defined extract
+     * directory.
+     * 
+     * @param cabFile
+     *            CAB file
+     * @param filter
+     *            which files to extract (extract all files if
+     *            <code>null</code>)
+     * @param extractDirectory
+     *            directory to extract files (no sub-directory will be created)
+     */
+    public CabExtractor(File cabFile, CabFileFilter filter, File extractDirectory)
+            throws CabException, IOException {
+        this(cabFile, filter, new DefaultCabFileSaver(extractDirectory));
+    }
+
+    /**
+     * To extract some files from CAB file and handle (save) them using
+     * {@link CabFileSaver}.
+     * 
+     * @param cabFile
+     *            CAB file
+     * @param filter
+     *            which files to extract (extract all files if
+     *            <code>null</code>)
+     * @param saver
+     *            defines how to save the extracted
+     *            {@link ByteArrayOutputStream} corresponding to
+     *            {@link CabFileEntry}
+     */
+    public CabExtractor(File cabFile, CabFileFilter filter, CabFileSaver saver)
+            throws CabException, IOException {
+        this.inputStream = new BufferedInputStream(new FileInputStream(cabFile));
+        this.parser = new CabParser(this.inputStream, new FilteredCabStreamSaver(saver, filter));
+    }
+
+    /**
+     * To extract some files from CAB {@link InputStream} and handle (save) them
+     * using {@link CabFileSaver}.
+     * 
+     * @param inputStream
+     *            representing CAB file
+     * @param filter
+     *            which files to extract (extract all files if
+     *            <code>null</code>)
+     * @param saver
+     *            defines how to save the extracted
+     *            {@link ByteArrayOutputStream} corresponding to
+     *            {@link CabFileEntry}
+     */
+    public CabExtractor(InputStream inputStream, CabFileFilter filter, CabFileSaver saver)
+            throws CabException, IOException {
+        this(inputStream, new FilteredCabStreamSaver(saver, filter));
+    }
+
+    /**
+     * To extract files from CAB {@link InputStream} and handle (save) them
+     * using {@link CabStreamSaver}.
+     * 
+     * @param inputStream
+     *            representing CAB file
+     * @param streamSaver
+     *            defines which files to save and how to save them
+     */
+    public CabExtractor(InputStream inputStream, CabStreamSaver streamSaver)
+            throws CabException, IOException {
+        this.inputStream = inputStream;
+        this.parser = new CabParser(this.inputStream, streamSaver);
+    }
+
+    /**
+     * Extract files from CAB stream using the strategy defined by constructor
+     * parameter(s). Only first invocation of this method extracts files (mostly
+     * because we are extracting from potentially non-rewindable CAB stream, but
+     * also because extracting with predefined parameters is an idempotent
+     * operation).
+     * 
+     * @return <code>true</code> if files were extracted, <code>false</code>
+     *         otherwise (if executed second time on the same
+     *         {@link CabExtractor) object)
+     */
+    public boolean extract() throws CabException, IOException {
+        boolean result = done.compareAndSet(false, true);
+        if (result) {
+            try {
+                parser.extractStream();
+            } finally {
+                inputStream.close();
+            }
+        }
+        return result;
+    }
+
+    public static String getVersion() {
+        return CabParser.getVersion();
+    }
+
+    public Enumeration<Object> entries() {
+        return parser.entries();
+    }
+
+    public Enumeration<Object> entries(boolean b) {
+        return parser.entries(b);
+    }
+
+    public CabHeader getHeader() {
+        return parser.header;
+    }
+
+    public CabFolderEntry[] getFolders() {
+        return parser.folders;
+    }
+
+    public CabFileEntry[] getFiles() {
+        return parser.files;
+    }
+
+}

--- a/src/dorkbox/cabParser/extractor/CabFileFilter.java
+++ b/src/dorkbox/cabParser/extractor/CabFileFilter.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dorkbox/cabParser/extractor/CabFileFilter.java
+++ b/src/dorkbox/cabParser/extractor/CabFileFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import dorkbox.cabParser.structure.CabFileEntry;
+
+/**
+ * Implement it to select files to extract from CAB.
+ */
+public interface CabFileFilter {
+
+    /**
+     * Is invoked on each File Entry found in CAB file.
+     * 
+     * @return <code>true</code> to extract file, <code>false</code> to ignore
+     */
+    public boolean test(CabFileEntry cabFile);
+}

--- a/src/dorkbox/cabParser/extractor/CabFilePatternFilter.java
+++ b/src/dorkbox/cabParser/extractor/CabFilePatternFilter.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dorkbox/cabParser/extractor/CabFilePatternFilter.java
+++ b/src/dorkbox/cabParser/extractor/CabFilePatternFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import java.util.regex.Pattern;
+
+import dorkbox.cabParser.structure.CabFileEntry;
+
+/**
+ * Selects files to extract using case-insensitive regular expression pattern.
+ * Note that the file names (passed to regular expression) may contain paths
+ * delimited with backslash character ('\\').
+ */
+public class CabFilePatternFilter implements CabFileFilter {
+
+    private final Pattern pattern;
+
+    /**
+     * Creates {@link CabFilePatternFilter}.
+     * 
+     * @param regex
+     *            regular expression to match file name to extract (will be
+     *            compiled as case-insensitive)
+     */
+    public CabFilePatternFilter(String regex) {
+        this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+    }
+
+    /**
+     * Creates {@link CabFilePatternFilter}.
+     * 
+     * @param pattern
+     *            regular expression pattern to match file name to extract (will
+     *            be turned to case-insensitive)
+     */
+    public CabFilePatternFilter(Pattern pattern) {
+        this.pattern = Pattern.compile(pattern.pattern(), Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    public boolean test(CabFileEntry cabFile) {
+        return pattern.matcher(cabFile.getName()).matches();
+    }
+
+}

--- a/src/dorkbox/cabParser/extractor/CabFileSaver.java
+++ b/src/dorkbox/cabParser/extractor/CabFileSaver.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import java.io.ByteArrayOutputStream;
+
+import dorkbox.cabParser.structure.CabFileEntry;
+
+/**
+ * To define how to handle (save) the file content, corresponding to each
+ * individual file extracted from CAB.
+ */
+public interface CabFileSaver {
+
+    /**
+     * Save the extracted file content.
+     * 
+     * @param fileContent
+     *            extracted file content
+     * @param cabFile
+     *            {@link CabFileEntry} defining file to be be saved
+     */
+    void save(ByteArrayOutputStream fileContent, CabFileEntry cabFile);
+
+    /**
+     * @return amount successfully saved files
+     */
+    int getSucceeded();
+
+    /**
+     * @return amount of failed save attempts
+     */
+    int getFailed();
+}

--- a/src/dorkbox/cabParser/extractor/CabFileSaver.java
+++ b/src/dorkbox/cabParser/extractor/CabFileSaver.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dorkbox/cabParser/extractor/CabFileSetFilter.java
+++ b/src/dorkbox/cabParser/extractor/CabFileSetFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import dorkbox.cabParser.structure.CabFileEntry;
+
+/**
+ * Selects files to extract (case-insensitive). Note that the file names in CAB
+ * file may contain paths delimited with backslash character ('\\').
+ */
+public class CabFileSetFilter implements CabFileFilter {
+
+    private final Set<String> fileNames;
+
+    /**
+     * Creates {@link CabFileSetFilter}.
+     * 
+     * @param fileName
+     *            single file name to extract (case-insensitive)
+     */
+    public CabFileSetFilter(final String fileName) {
+        this.fileNames = new HashSet<String>();
+        this.fileNames.add(fileName.toLowerCase());
+    }
+
+    /**
+     * Creates {@link CabFileSetFilter}.
+     * 
+     * @param fileNames
+     *            file names to extract (case-insensitive)
+     */
+    public CabFileSetFilter(final Iterable<String> fileNames) {
+        this.fileNames = new HashSet<String>();
+        for (String i : fileNames) {
+            this.fileNames.add(i.toLowerCase());
+        }
+    }
+
+    @Override
+    public boolean test(CabFileEntry cabFile) {
+        String fileName = cabFile.getName().toLowerCase();
+        return fileNames.contains(fileName);
+    }
+
+}

--- a/src/dorkbox/cabParser/extractor/CabFileSetFilter.java
+++ b/src/dorkbox/cabParser/extractor/CabFileSetFilter.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dorkbox/cabParser/extractor/DefaultCabFileSaver.java
+++ b/src/dorkbox/cabParser/extractor/DefaultCabFileSaver.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dorkbox/cabParser/extractor/DefaultCabFileSaver.java
+++ b/src/dorkbox/cabParser/extractor/DefaultCabFileSaver.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import dorkbox.cabParser.structure.CabFileEntry;
+
+/**
+ * Saves extracted file content to a file.
+ */
+public class DefaultCabFileSaver implements CabFileSaver {
+
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("\\.(?=[^\\.]+$)");
+    private final File extractDirectory;
+    private AtomicInteger succeeded = new AtomicInteger(0);
+    private AtomicInteger failed = new AtomicInteger(0);
+
+    /**
+     * Creates {@link CabFileSaver}.
+     * 
+     * @param baseDirectory
+     *            base directory where a sub-directory will be created
+     * @param cabFile
+     *            to define a sub-directory for extracting files from CAB
+     */
+    public DefaultCabFileSaver(File baseDirectory, File cabFile) {
+        this.extractDirectory = new File(null == baseDirectory ? new File(".") : baseDirectory,
+                getFileNameBase(cabFile));
+        if (!this.extractDirectory.exists())
+            this.extractDirectory.mkdirs();
+    }
+
+    /**
+     * Creates {@link CabFileSaver}.
+     * 
+     * @param extractDirectory
+     *            target directory where the extracted files will be created
+     */
+    public DefaultCabFileSaver(File extractDirectory) {
+        this.extractDirectory = (null == extractDirectory ? new File(".") : extractDirectory);
+        if (!this.extractDirectory.exists())
+            this.extractDirectory.mkdirs();
+    }
+
+    @Override
+    public void save(ByteArrayOutputStream outputStream, CabFileEntry cabFile) {
+        if (outputStream != null) {
+            try {
+                File file = new File(getExtractDirectory(), cabFile.getName().replace("\\", File.separator));
+                file.getParentFile().mkdirs();
+                FileOutputStream writer = new FileOutputStream(file);
+                try {
+                    outputStream.writeTo(writer);
+                } finally {
+                    writer.close();
+                }
+                succeeded.incrementAndGet();
+            } catch (IOException e) {
+                failed.incrementAndGet();
+            } finally {
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+    }
+
+    @Override
+    public int getSucceeded() {
+        return succeeded.get();
+    }
+
+    @Override
+    public int getFailed() {
+        return failed.get();
+    }
+
+    public File getExtractDirectory() {
+        return extractDirectory;
+    }
+
+    public static String getFileNameBase(File file) {
+        return FILENAME_PATTERN.split(file.getName())[0];
+    }
+}

--- a/src/dorkbox/cabParser/extractor/FilteredCabStreamSaver.java
+++ b/src/dorkbox/cabParser/extractor/FilteredCabStreamSaver.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dorkbox.cabParser.extractor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.OutputStream;
+
+import dorkbox.cabParser.CabStreamSaver;
+import dorkbox.cabParser.structure.CabFileEntry;
+
+/**
+ * Implementation of {@link CabStreamSaver} that filters files to extract.
+ * {@link CabFileFilter} and saves them using {@link CabFileSaver}.
+ */
+public class FilteredCabStreamSaver implements CabStreamSaver {
+
+    private final CabFileSaver saver;
+    private final CabFileFilter filter;
+
+    /**
+     * To save all files to defined extract directory.
+     * 
+     * @param extractDirectory
+     *            directory to extract files (no sub-directory will be created)
+     */
+    public FilteredCabStreamSaver(File extractDirectory) {
+        this(extractDirectory, null);
+    }
+
+    /**
+     * To handle (save) all files using passed {@link CabFileSaver}.
+     * 
+     * @param saver
+     *            defines how to save the {@link ByteArrayOutputStream}
+     *            corresponding to {@link CabFileEntry}
+     */
+    public FilteredCabStreamSaver(CabFileSaver saver) {
+        this(saver, null);
+    }
+
+    /**
+     * To save some files to defined extract directory.
+     * 
+     * @param extractDirectory
+     *            directory to extract files (no sub-directory will be created)
+     * @param filter
+     *            which files to extract (extract all files if
+     *            <code>null</code>)
+     */
+    public FilteredCabStreamSaver(File extractDirectory, CabFileFilter filter) {
+        this(new DefaultCabFileSaver(extractDirectory), filter);
+    }
+
+    /**
+     * To handle (save) some files using passed {@link CabFileSaver}.
+     * 
+     * @param saver
+     *            defines how to save the {@link ByteArrayOutputStream}
+     *            corresponding to {@link CabFileEntry}
+     * @param filter
+     *            which files to extract (extract all files if
+     *            <code>null</code>)
+     */
+    public FilteredCabStreamSaver(CabFileSaver saver, CabFileFilter filter) {
+        this.saver = null == saver ? new DefaultCabFileSaver(null) : saver;
+        this.filter = null == filter ? new CabFilePatternFilter(".+") : filter;
+    }
+
+    @Override
+    public void closeOutputStream(OutputStream outputStream, CabFileEntry cabFile) {
+        saver.save((ByteArrayOutputStream) outputStream, cabFile);
+    }
+
+    @Override
+    public OutputStream openOutputStream(CabFileEntry cabFile) {
+        if (filter.test(cabFile)) {
+            return new ByteArrayOutputStream((int) cabFile.getSize());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean saveReservedAreaData(byte[] data, int dataLength) {
+        return false;
+    }
+
+    /**
+     * @return amount successfully saved files
+     */
+    public int getSucceeded() {
+        return saver.getSucceeded();
+    }
+
+    /**
+     * @return amount of failed save attempts
+     */
+    public int getFailed() {
+        return saver.getFailed();
+    }
+
+}

--- a/src/dorkbox/cabParser/extractor/FilteredCabStreamSaver.java
+++ b/src/dorkbox/cabParser/extractor/FilteredCabStreamSaver.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2019 dorkbox, llc
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
The most significant bug fix is in CabDecompressor. Without that fix, extracting files from CAB file containing many (thousands) files (and consequently belonging to more than one CFFOLDER) is a nightmare: you have to extract either all of them or one of them at once (from the same CAB InputStream), otherwise the content of some extracted files will be invalid.